### PR TITLE
fix: prevent build-and-release job from running on non-main branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -107,6 +107,7 @@ jobs:
     needs: [quality-verification, test-matrix]
     runs-on: ubuntu-latest
     environment: release
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       id-token: write
@@ -160,19 +161,8 @@ jobs:
 
       - name: Semantic Release
         run: |
-          echo "🔍 Debug info:"
-          echo "Branch: ${{ github.ref }}"
-          echo "Event: ${{ github.event_name }}"
-          echo "Repository: ${{ github.repository }}"
-          echo "Actor: ${{ github.actor }}"
-          
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "🚀 Running semantic release on main branch"
-            npx semantic-release
-          else
-            echo "📝 Running semantic release dry-run on feature branch"
-            npx semantic-release --dry-run
-          fi
+          echo "🚀 Running semantic release on main branch"
+          npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Added explicit branch condition to build-and-release job to ensure it only runs on main branch pushes. This prevents semantic-release from failing on feature branches where it shouldn't run.

- Add if condition to build-and-release job
- Simplify semantic-release step since it only runs on main
- Prevents unnecessary release attempts on feature branches

🤖 Generated with [Claude Code](https://claude.ai/code)