### PR TITLE
fix: handle missing NPM_TOKEN gracefully with GitHub-only releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -174,18 +174,32 @@ jobs:
           fi
           
           if [[ -z "$NPM_TOKEN" ]]; then
-            echo "⚠️ NPM_TOKEN is not set - proceeding anyway (GitHub release only)"
+            echo "⚠️ NPM_TOKEN is not set"
+            echo "📝 Creating GitHub-only release (no NPM publishing)"
+            echo ""
+            echo "To enable NPM publishing, please:"
+            echo "1. Generate an NPM access token at https://www.npmjs.com/settings/tokens"
+            echo "2. Add it as NPM_TOKEN secret in repository settings"
+            echo "3. Re-run this workflow or push new commits"
+            echo ""
+            
+            # Create a temporary semantic-release config for GitHub-only releases
+            cat > .releaserc.tmp.json << 'EOF'
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}
+EOF
+            npx semantic-release --extends ./.releaserc.tmp.json
+            rm -f .releaserc.tmp.json
+          else
+            echo "✅ NPM_TOKEN is set - proceeding with full release"
+            npx semantic-release
           fi
-          
-          # Run semantic release with verbose output
-          npx semantic-release --debug || {
-            echo "❌ Semantic release failed"
-            echo "This might be expected if:"
-            echo "- No releasable commits since last release"
-            echo "- Branch protection rules prevent releases"
-            echo "- NPM authentication issues"
-            exit 0
-          }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/setup-npm-token.md
+++ b/scripts/setup-npm-token.md
@@ -1,0 +1,45 @@
+# NPM Token Setup Guide
+
+To enable NPM publishing in the CI/CD pipeline, you need to set up an NPM access token.
+
+## Steps to Create NPM Token
+
+1. **Log in to NPM**
+   - Go to https://www.npmjs.com/
+   - Sign in to your account (or create one if needed)
+
+2. **Generate Access Token**
+   - Go to https://www.npmjs.com/settings/tokens
+   - Click "Generate New Token"
+   - Choose "Automation" token type (for CI/CD)
+   - Copy the generated token
+
+3. **Add Token to GitHub Secrets**
+   - Go to your repository settings on GitHub
+   - Navigate to "Secrets and variables" > "Actions"
+   - Click "New repository secret"
+   - Name: `NPM_TOKEN`
+   - Value: Paste your NPM token
+   - Click "Add secret"
+
+## Verification
+
+After adding the NPM_TOKEN secret:
+1. Push new commits to main branch
+2. The release workflow will automatically publish to NPM
+3. Check the workflow logs to confirm successful publishing
+
+## Alternative: Manual Publishing
+
+If you prefer to publish manually:
+```bash
+npm login
+npm publish
+```
+
+## Package Scope
+
+If publishing a scoped package (@username/package), ensure:
+- Your NPM token has access to the scope
+- The package.json name matches the scope
+- You have publishing permissions for that scope


### PR DESCRIPTION
Added fallback logic to create GitHub-only releases when NPM_TOKEN is not set, preventing workflow failures while providing clear setup instructions.

- Create temporary semantic-release config for GitHub-only releases
- Provide detailed NPM token setup instructions in workflow output
- Add NPM token setup guide documentation
- Maintain full functionality when NPM_TOKEN is available

🤖 Generated with [Claude Code](https://claude.ai/code)