### PR TITLE
Fix ESLint errors in GitContextService

### DIFF
--- a/src/services/GitContextService.ts
+++ b/src/services/GitContextService.ts
@@ -75,7 +75,7 @@ export class GitContextService {
 
       // Development context indicators
       if (
-        commitMessages.match(/(feat|fix|refactor|perf)/i) ||
+        commitMessages.match(/(feat|fix|refactor|perf)/i) ||
         fileExtensions.some((ext) =>
           [".go", ".java", ".js", ".py", ".ts"].includes(ext),
         )
@@ -85,7 +85,7 @@ export class GitContextService {
 
       // Documentation context indicators
       if (
-        commitMessages.match(/(docs|readme|documentation)/i) ||
+        commitMessages.match(/(docs|readme|documentation)/i) ||
         fileExtensions.some((ext) => [".md", ".rst", ".txt"].includes(ext))
       ) {
         return "pm"; // PM often handles documentation
@@ -93,7 +93,7 @@ export class GitContextService {
 
       // Test context indicators
       if (
-        commitMessages.match(/(test|spec|coverage)/i) ||
+        commitMessages.match(/(test|spec|coverage)/i) ||
         gitContext.modifiedFiles.some((file) => file.includes("test"))
       ) {
         return "qa";
@@ -101,7 +101,7 @@ export class GitContextService {
 
       // Architecture context indicators
       if (
-        commitMessages.match(/(architect|design|structure)/i) ||
+        commitMessages.match(/(architect|design|structure)/i) ||
         gitContext.modifiedFiles.some((file) => file.includes("architecture"))
       ) {
         return "architect";
@@ -292,13 +292,14 @@ export class GitContextService {
           case "M":
             changes.modified.push(filename);
             break;
-          case "R":
+          case "R": {
             // Renamed files have format "R  old -> new"
             const [oldName, newName] = filename.split(" -> ");
             if (oldName && newName) {
               changes.renamed.push({ from: oldName, to: newName });
             }
             break;
+          }
         }
       }
 


### PR DESCRIPTION
- Fix lexical declaration in case block by adding braces around case 'R'
- Remove control characters (\x08) from regex patterns that were causing no-control-regex warnings
- All ESLint errors resolved, only leaving pre-existing warnings

This fixes the GitHub Actions build failures.

🤖 Generated with [Claude Code](https://claude.ai/code)