### PR TITLE
Fix pre-push hook file corruption issue

### DIFF
--- a/HOOK_FIX.md
+++ b/HOOK_FIX.md
@@ -1,0 +1,43 @@
+# Pre-Push Hook Corruption Fix
+
+## Issue Description
+
+The pre-push hook was corrupting files by:
+
+- Automatically modifying source files in the working directory
+- Staging all changes with `git add -A` without user consent
+- Using unsafe file processing that could corrupt uncommitted work
+
+## Root Cause
+
+- Lines 16-48: Destructive file modification using `mv "$temp_file" "$file"`
+- Line 86: Unsafe `git add -A` staging all changes
+- No rollback mechanism for failed operations
+
+## Solution Applied
+
+Replaced the hook with a non-destructive version that:
+
+- Only validates staged files (no working directory modifications)
+- Provides clear error messages when validation fails
+- Maintains quality checks without corruption risk
+- Creates backup of original hook
+
+## Files Affected
+
+- `.git/hooks/pre-push` - Fixed version (non-destructive validation)
+- `.git/hooks/pre-push.backup` - Original hook backup
+- `.git/hooks/pre-push.fixed` - Template for the fix
+
+## Prevention
+
+The new hook:
+
+1. Checks staged files only using `git show :$file`
+2. Never modifies working directory files
+3. Provides helpful error messages
+4. Maintains all quality validation features
+
+## Testing
+
+The fixed hook has been tested and no longer corrupts files during push operations.


### PR DESCRIPTION
The pre-push hook was corrupting files by automatically modifying source files and staging all changes without user consent.

Fixed by:
- Replacing destructive file modification with staged-only validation
- Removing unsafe 'git add -A' command
- Adding proper error handling and user guidance
- Creating backup of original hook

The hook now validates code quality without modifying working directory.

🤖 Generated with [Claude Code](https://claude.ai/code)