### PR TITLE
Fix npm pack tarball extraction in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -105,7 +105,7 @@ jobs:
           
           # Run npm pack and capture output to temp file
           if npm pack > /tmp/pack_output.txt 2>&1; then
-            TARBALL=$(cat /tmp/pack_output.txt | grep '\.tgz$' || echo "permamind-2.18.2.tgz")
+            TARBALL=$(cat /tmp/pack_output.txt | grep '\.tgz$' | tail -1 || echo "permamind-2.18.2.tgz")
             echo "Created tarball: $TARBALL"
           else
             PACK_EXIT=$?


### PR DESCRIPTION
The grep command was returning multiple lines including both the npm notice and the actual tarball filename. Added `tail -1` to extract only the last line which contains the actual tarball filename, fixing the package validation step failure in the npm-publish workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)