### PR TITLE
Fix production environment configuration for mainnet deployment

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -219,7 +219,7 @@ jobs:
           git push --tags
 
       - name: Build for publishing
-        run: npm run build
+        run: npm run build:prod
 
       - name: Publish to NPM (dry-run)
         if: github.event.inputs.dry_run == 'true'
@@ -232,6 +232,7 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_ENV: production
 
       - name: Post-publish verification
         if: github.event.inputs.dry_run != 'true'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "preferGlobal": true,
   "scripts": {
     "build": "tsc",
+    "build:prod": "NODE_ENV=production tsc",
     "start": "tsx src/server.ts",
     "dev": "fastmcp dev src/server.ts",
     "lint": "prettier --check . && eslint . && tsc --noEmit",


### PR DESCRIPTION
- Add build:prod script to package.json for production builds
- Update npm-publish workflow to use NODE_ENV=production
- Ensures isMainnet() returns true for published packages
- Resolves issue where production deployments used testnet endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)