### PR TITLE
Fix Git push in CI workflow for version bumping

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -187,8 +187,8 @@ jobs:
             npm version patch
           fi
           
-          # Push the version commit and tags
-          git push origin main
+          # Push the version commit and tags to current branch and main
+          git push origin HEAD:main
           git push --tags
 
       - name: Build for publishing


### PR DESCRIPTION
- Change git push from 'origin main' to 'origin HEAD:main' to work from any branch
- Ensures version bump commits reach main branch regardless of source branch

🤖 Generated with [Claude Code](https://claude.ai/code)