### PR TITLE
Fix keypair persistence issue with seed phrases

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,6 +15,7 @@ export default tseslint.config(
     files: [
       "src/services/**/*.ts",
       "src/tools/process/commands/*.ts",
+      "src/tools/core/ContextHelpers.ts",
       "src/models/WorkflowMemory.ts",
       "tests/**/*.ts",
     ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,14 @@ export const getCurrentUserState = () => ({
   publicKey,
 });
 
+// Export getter for current context (dynamic)
+export const getCurrentContext = (): ToolContext => ({
+  embeddedTemplates,
+  hubId,
+  keyPair,
+  publicKey,
+});
+
 // Export setter for server state (used by hub initialization tools)
 export const setUserState = (newState: {
   hubId?: string;

--- a/src/tools/core/ContextHelpers.ts
+++ b/src/tools/core/ContextHelpers.ts
@@ -65,47 +65,65 @@ export async function autoPublicKey(context: ToolContext): Promise<string> {
 /**
  * Helper to safely extract hubId with non-null assertion
  */
-export function safeHubId(context: ToolContext): string {
-  if (!context.hubId) {
+export async function safeHubId(_context: ToolContext): Promise<string> {
+  // Get fresh context to check current state
+  const { getCurrentContext } = await import("../../server.js");
+  const currentContext = getCurrentContext();
+
+  if (!currentContext.hubId) {
     throw new Error("Hub not initialized. Please run initializeHub first.");
   }
-  return context.hubId;
+  return currentContext.hubId;
 }
 
 /**
  * Helper to safely extract keyPair with non-null assertion
  * This provides better error messaging during development
  */
-export function safeKeyPair(context: ToolContext): JWKInterface {
-  if (!context.keyPair) {
+export async function safeKeyPair(
+  _context: ToolContext,
+): Promise<JWKInterface> {
+  // Get fresh context to check current state
+  const { getCurrentContext } = await import("../../server.js");
+  const currentContext = getCurrentContext();
+
+  if (!currentContext.keyPair) {
     throw new Error("Wallet not initialized. Please run initializeHub first.");
   }
-  return context.keyPair;
+  return currentContext.keyPair;
 }
 
 /**
  * Helper to safely extract publicKey with non-null assertion
  */
-export function safePublicKey(context: ToolContext): string {
-  if (!context.publicKey) {
+export async function safePublicKey(_context: ToolContext): Promise<string> {
+  // Get fresh context to check current state
+  const { getCurrentContext } = await import("../../server.js");
+  const currentContext = getCurrentContext();
+
+  if (!currentContext.publicKey) {
     throw new Error("Wallet not initialized. Please run initializeHub first.");
   }
-  return context.publicKey;
+  return currentContext.publicKey;
 }
 
 /**
  * Auto-generates a keypair if none exists in the context
  */
-async function autoGenerateKeypair(context: ToolContext): Promise<{
+async function autoGenerateKeypair(_context: ToolContext): Promise<{
   generated: boolean;
   keyPair: JWKInterface;
   publicKey: string;
 }> {
-  if (context.keyPair && context.publicKey) {
+  // Get fresh context to check current state
+  const { getCurrentContext } = await import("../../server.js");
+  const currentContext = getCurrentContext();
+
+  if (currentContext.keyPair && currentContext.publicKey) {
     return {
       generated: false,
-      keyPair: context.keyPair,
-      publicKey: context.publicKey,
+      keyPair: currentContext.keyPair,
+      publicKey: currentContext.publicKey,
     };
   }
 
@@ -139,12 +157,16 @@ async function autoGenerateKeypair(context: ToolContext): Promise<{
 async function autoInitializeHub(
   keyPair: JWKInterface,
   publicKey: string,
-  context: ToolContext,
+  _context: ToolContext,
 ): Promise<{ created: boolean; hubId: string }> {
-  if (context.hubId) {
+  // Get fresh context to check current state
+  const { getCurrentContext } = await import("../../server.js");
+  const currentContext = getCurrentContext();
+
+  if (currentContext.hubId) {
     return {
       created: false,
-      hubId: context.hubId,
+      hubId: currentContext.hubId,
     };
   }
 


### PR DESCRIPTION
## Summary
Resolves the issue where generated keypairs didn't persist even when a seed phrase was provided. This was caused by a static context problem where tools received outdated context objects that didn't reflect server state changes.

## Key Changes
- **Dynamic Context System**: Added `getCurrentContext()` function to `server.ts` for real-time context access
- **Context Helper Updates**: Modified `ContextHelpers.ts` to use dynamic context instead of static context 
- **GenerateKeypairCommand Enhancement**: Added existing state checking and proper persistence
- **Comprehensive Test Coverage**: Added tests for persistence behavior, environment variable usage, and parameter handling
- **ESLint Configuration**: Updated config to handle unused parameters in ContextHelpers

## Test Plan
✅ Seed phrases now persist correctly across multiple calls  
✅ Environment variable `SEED_PHRASE` is automatically used when available   
✅ Both parameter-based and environment-based seed phrases work  
✅ Deterministic keypair generation from seed phrases  
✅ Proper state management with server persistence  
✅ All existing tests pass  
✅ Code quality checks pass  

## Validation Results
- **First call**: Generates keypair from seed phrase and stores in server state
- **Subsequent calls**: Returns the same keypair from server state (persistence working)
- **Deterministic**: Same seed phrase always produces same public key: `CK-1OqFAIsqyPVfBE0q6n7gnNGvVoPPF8LTNJ7bdzHI`

🤖 Generated with [Claude Code](https://claude.ai/code)