### PR TITLE
Clarify SpawnProcessCommand usage and remove Permamind references

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,4 @@
-# Permamind CI/CD Pipeline Documentation
+# Permaweb MCP CI/CD Pipeline Documentation
 
 ## Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ const uploadResult = await turboService.uploadFile(filePath, contentType, tags);
 
 ### ArNS Operations
 
-Permamind provides comprehensive ArNS domain management capabilities:
+This project (Permaweb MCP) provides comprehensive ArNS domain management capabilities:
 
 - **Record Management**: Purchase, extend, and release ArNS names
 - **Undername Limits**: Increase undername capacity for domains

--- a/src/services/DocumentationProtocolService.ts
+++ b/src/services/DocumentationProtocolService.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
  * document their capabilities through an enhanced Info handler.
  *
  * The protocol extends existing Info handlers to include comprehensive metadata,
- * making processes self-documenting and enabling tools like Permamind's
+ * making processes self-documenting and enabling tools like Permaweb MCP's
  * executeAction to automatically discover process capabilities.
  */
 

--- a/src/tools/process/ProcessToolFactory.ts
+++ b/src/tools/process/ProcessToolFactory.ts
@@ -6,7 +6,7 @@ import { SpawnProcessCommand } from "./commands/SpawnProcessCommand.js";
 
 /**
  * Factory for creating core AO process management tools that provide essential
- * process lifecycle management capabilities in the Permamind MCP server.
+ * process lifecycle management capabilities in the Permaweb MCP server.
  *
  * The ProcessToolFactory provides four core tools for fundamental AO process operations:
  *
@@ -57,7 +57,7 @@ import { SpawnProcessCommand } from "./commands/SpawnProcessCommand.js";
  * @see {@link QueryAOProcessMessagesCommand} For process message querying
  *
  * @since 1.0.0
- * @author Permamind Development Team
+ * @author Permaweb MCP Development Team
  */
 export class ProcessToolFactory extends BaseToolFactory {
   /**

--- a/src/tools/process/commands/SpawnProcessCommand.ts
+++ b/src/tools/process/commands/SpawnProcessCommand.ts
@@ -16,7 +16,7 @@ interface SpawnProcessArgs extends Record<string, never> {
 export class SpawnProcessCommand extends ToolCommand<SpawnProcessArgs, string> {
   protected metadata: ToolMetadata = {
     description:
-      "Spawn an empty AO process container (no code) and return its process ID. This creates a fresh AO process using the default AOS module configuration, ready for code deployment via sendAOMessage. DEPLOYMENT WORKFLOW: Step 1 of 2: 1) spawnProcess (this tool) → 2) sendAOMessage with Action: Eval tag to deploy code. DO NOT use aos CLI - use Permamind tools only. Use 'spawn empty process' or 'spawn process' to trigger this tool. Automatically initializes wallet and hub if needed.",
+      "LOW-LEVEL INFRASTRUCTURE TOOL: Spawns an empty AO process container on the Arweave network and returns its process ID. This is for infrastructure operations like creating storage containers or registry processes - NOT for developing AO applications. FOR AO APPLICATION DEVELOPMENT: Use the 'ao' skill instead to write, test, and deploy complete AO processes with proper Lua code. This tool only creates empty process shells without code. Use cases: Creating dedicated storage processes, spawning process registries, or infrastructure components. Workflow: 1) spawnProcess (creates empty container) → 2) sendAOMessage with Action: Eval (deploys code). Automatically initializes wallet if needed.",
     name: "spawnProcess",
     openWorldHint: false,
     readOnlyHint: false,


### PR DESCRIPTION
- Update SpawnProcessCommand description to clearly distinguish it as a low-level infrastructure tool
- Add explicit guidance to use 'ao' skill for AO application development instead of this tool
- Replace all 'Permamind' references with 'Permaweb MCP' in source code and documentation
- Updated files: SpawnProcessCommand.ts, ProcessToolFactory.ts, DocumentationProtocolService.ts, CLAUDE.md, .github/workflows/README.md

This prevents confusion when both ao skill and permaweb-mcp server are used together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)