### PR TITLE
Update repository URL to reflect correct GitHub repository name

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ALLiDoizCode/Permamind.git"
+    "url": "https://github.com/ALLiDoizCode/Permaweb-MCP.git"
   },
   "author": "Jonathan Green <dev.jonathan.green@gmail.com>",
   "homepage": "https://x.com/allidoizcode",


### PR DESCRIPTION
Changed repository URL from Permamind to Permaweb-MCP to match the actual repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)